### PR TITLE
streamer: Sign TLS cert with validator identity key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,6 +1662,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "gag"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3027,6 +3036,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "pem"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
+dependencies = [
+ "base64 0.13.0",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3361,6 +3379,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quinn"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a84d97630b137463c8e6802adc1dfe9de81457b41bb1ac59189e6761ab9255"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-channel",
+ "futures-util",
+ "fxhash",
+ "quinn-proto",
+ "quinn-udp",
+ "rustls 0.20.2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063dedf7983c8d57db474218f258daa85b627de6f2dbc458b690a93b1de790e8"
+dependencies = [
+ "bytes 1.1.0",
+ "fxhash",
+ "rand 0.8.4",
+ "ring",
+ "rustls 0.20.2",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7996776e9ee3fc0e5c14476c1a640a17e993c847ae9c81191c2c102fbef903"
+dependencies = [
+ "futures-util",
+ "libc",
+ "mio 0.7.14",
+ "quinn-proto",
+ "socket2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3650,6 +3722,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5911d1403f4143c9d56a702069d593e8d0f3fab880a85e103604d0893ea31ba7"
+dependencies = [
+ "chrono",
+ "pem",
+ "ring",
+ "yasna",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3863,14 +3947,35 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5ac6078ca424dc1d3ae2328526a76787fecc7f8011f520e3276730e711fc95"
+checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
 dependencies = [
  "log 0.4.14",
  "ring",
  "sct 0.7.0",
  "webpki 0.22.0",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca9ebdfa27d3fc180e42879037b5338ab1c040c06affd00d8338598e7800943"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -4717,14 +4822,18 @@ dependencies = [
  "base64 0.13.0",
  "bincode",
  "bs58 0.4.0",
+ "bytes 1.1.0",
  "clap 2.33.3",
  "crossbeam-channel",
+ "futures 0.3.19",
  "indicatif",
  "jsonrpc-core",
  "jsonrpc-http-server",
  "log 0.4.14",
+ "quinn",
  "rayon",
  "reqwest",
+ "rustls 0.20.2",
  "semver 1.0.4",
  "serde",
  "serde_derive",
@@ -5788,6 +5897,7 @@ dependencies = [
  "num-traits",
  "pbkdf2 0.10.0",
  "qstring",
+ "quinn",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "rustc_version 0.4.0",
@@ -5939,16 +6049,21 @@ name = "solana-streamer"
 version = "1.10.0"
 dependencies = [
  "crossbeam-channel",
+ "futures-util",
  "histogram",
  "itertools 0.10.3",
  "libc",
  "log 0.4.14",
  "nix",
+ "quinn",
+ "rcgen",
+ "rustls 0.20.2",
  "solana-logger 1.10.0",
  "solana-metrics",
  "solana-perf",
  "solana-sdk",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -7091,7 +7206,7 @@ dependencies = [
  "httparse",
  "log 0.4.14",
  "rand 0.8.4",
- "rustls 0.20.0",
+ "rustls 0.20.2",
  "sha-1 0.9.8",
  "thiserror",
  "url 2.2.2",
@@ -7638,6 +7753,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "yasna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262a29d0e61ccf2b6190d7050d4b237535fc76ce4c1210d9caa316f71dffa75"
+dependencies = [
+ "chrono",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "base64ct"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874f8444adcb4952a8bc51305c8be95c8ec8237bb0d2e78d2e039f771f8828a0"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,6 +826,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+
+[[package]]
 name = "const_fn"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,6 +1095,15 @@ dependencies = [
  "cfg-if 1.0.0",
  "num_cpus",
  "rayon",
+]
+
+[[package]]
+name = "der"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+dependencies = [
+ "const-oid",
 ]
 
 [[package]]
@@ -3153,6 +3174,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+dependencies = [
+ "der",
+ "spki",
+ "zeroize",
+]
 
 [[package]]
 name = "pkg-config"
@@ -6055,8 +6087,11 @@ dependencies = [
  "libc",
  "log 0.4.14",
  "nix",
+ "pem",
+ "pkcs8",
  "quinn",
  "rcgen",
+ "ring",
  "rustls 0.20.2",
  "solana-logger 1.10.0",
  "solana-metrics",
@@ -6367,6 +6402,16 @@ name = "spin"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+
+[[package]]
+name = "spki"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "spl-associated-token-account"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -38,6 +38,11 @@ tokio = { version = "1", features = ["full"] }
 tungstenite = { version = "0.16.0", features = ["rustls-tls-webpki-roots"] }
 url = "2.2.2"
 
+futures = "0.3"
+quinn = "0.8.0"
+rustls = { version = "0.20.2", features = ["dangerous_configuration"] }
+bytes = "1.1.0"
+
 [dev-dependencies]
 assert_matches = "1.5.0"
 jsonrpc-http-server = "18.0.0"

--- a/client/src/client_error.rs
+++ b/client/src/client_error.rs
@@ -53,6 +53,13 @@ impl From<TransportError> for ClientErrorKind {
             TransportError::IoError(err) => Self::Io(err),
             TransportError::TransactionError(err) => Self::TransactionError(err),
             TransportError::Custom(err) => Self::Custom(err),
+            TransportError::SendDatagramError(err) => {
+                Self::Custom(format!("SendDatagramError: {:?}", err))
+            }
+            TransportError::ConnectionError(err) => {
+                Self::Custom(format!("ConnectionError: {:?}", err))
+            }
+            TransportError::ConnectError(err) => Self::Custom(format!("ConnectError: {:?}", err)),
         }
     }
 }

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -40,6 +40,7 @@ pub struct TpuSockets {
     pub transaction_forwards: Vec<UdpSocket>,
     pub vote: Vec<UdpSocket>,
     pub broadcast: Vec<UdpSocket>,
+    pub transactions_quic: UdpSocket,
 }
 
 pub struct Tpu {
@@ -49,6 +50,7 @@ pub struct Tpu {
     banking_stage: BankingStage,
     cluster_info_vote_listener: ClusterInfoVoteListener,
     broadcast_stage: BroadcastStage,
+    tpu_quic_t: thread::JoinHandle<()>,
 }
 
 impl Tpu {
@@ -81,6 +83,7 @@ impl Tpu {
             transaction_forwards: tpu_forwards_sockets,
             vote: tpu_vote_sockets,
             broadcast: broadcast_sockets,
+            transactions_quic: transactions_quic_sockets,
         } = sockets;
 
         let (packet_sender, packet_receiver) = unbounded();
@@ -96,6 +99,10 @@ impl Tpu {
             tpu_coalesce_ms,
         );
         let (verified_sender, verified_receiver) = unbounded();
+
+        let tpu_quic_t =
+            solana_streamer::quic::spawn_server(transactions_quic_sockets, packet_sender, exit.clone())
+                .unwrap();
 
         let sigverify_stage = {
             let verifier = TransactionSigVerifier::default();
@@ -160,6 +167,7 @@ impl Tpu {
             banking_stage,
             cluster_info_vote_listener,
             broadcast_stage,
+            tpu_quic_t,
         }
     }
 
@@ -171,11 +179,13 @@ impl Tpu {
             self.cluster_info_vote_listener.join(),
             self.banking_stage.join(),
         ];
+        self.tpu_quic_t.join()?;
         let broadcast_result = self.broadcast_stage.join();
         for result in results {
             result?;
         }
         let _ = broadcast_result?;
+        warn!("exiting tpu");
         Ok(())
     }
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -881,6 +881,7 @@ impl Validator {
                 transaction_forwards: node.sockets.tpu_forwards,
                 vote: node.sockets.tpu_vote,
                 broadcast: node.sockets.broadcast,
+                transactions_quic: node.sockets.tpu_quic,
             },
             &rpc_subscriptions,
             transaction_status_sender,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -532,7 +532,7 @@ impl Validator {
         }
 
         let mut cluster_info =
-            ClusterInfo::new(node.info.clone(), identity_keypair, socket_addr_space);
+            ClusterInfo::new(node.info.clone(), identity_keypair.clone(), socket_addr_space);
         cluster_info.set_contact_debug_interval(config.contact_debug_interval);
         cluster_info.set_entrypoints(cluster_entrypoints);
         cluster_info.restore_contact_info(ledger_path, config.contact_save_interval);
@@ -899,6 +899,7 @@ impl Validator {
             config.tpu_coalesce_ms,
             cluster_confirmed_slot_sender,
             &cost_model,
+            &identity_keypair,
         );
 
         datapoint_info!("validator-new", ("id", id.to_string(), String));

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2741,6 +2741,7 @@ pub struct Sockets {
     pub retransmit_sockets: Vec<UdpSocket>,
     pub serve_repair: UdpSocket,
     pub ancestor_hashes_requests: UdpSocket,
+    pub tpu_quic: UdpSocket,
 }
 
 #[derive(Debug)]
@@ -2757,6 +2758,8 @@ impl Node {
     pub fn new_localhost_with_pubkey(pubkey: &Pubkey) -> Self {
         let bind_ip_addr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
         let tpu = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let tpu_quic_port = tpu.local_addr().unwrap().port() + 1;
+        let tpu_quic = UdpSocket::bind(format!("127.0.0.1:{}", tpu_quic_port)).unwrap();
         let (gossip_port, (gossip, ip_echo)) =
             bind_common_in_range(bind_ip_addr, (1024, 65535)).unwrap();
         let gossip_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), gossip_port);
@@ -2806,6 +2809,7 @@ impl Node {
                 retransmit_sockets: vec![retransmit_socket],
                 serve_repair,
                 ancestor_hashes_requests,
+                tpu_quic,
             },
         }
     }
@@ -2841,6 +2845,7 @@ impl Node {
         let (tvu_port, tvu) = Self::bind(bind_ip_addr, port_range);
         let (tvu_forwards_port, tvu_forwards) = Self::bind(bind_ip_addr, port_range);
         let (tpu_port, tpu) = Self::bind(bind_ip_addr, port_range);
+        let (_tpu_port_quic, tpu_quic) = Self::bind(bind_ip_addr, (tpu_port + 1, tpu_port + 2));
         let (tpu_forwards_port, tpu_forwards) = Self::bind(bind_ip_addr, port_range);
         let (tpu_vote_port, tpu_vote) = Self::bind(bind_ip_addr, port_range);
         let (_, retransmit_socket) = Self::bind(bind_ip_addr, port_range);
@@ -2884,6 +2889,7 @@ impl Node {
                 retransmit_sockets: vec![retransmit_socket],
                 serve_repair,
                 ancestor_hashes_requests,
+                tpu_quic,
             },
         }
     }
@@ -2905,6 +2911,8 @@ impl Node {
 
         let (tpu_port, tpu_sockets) =
             multi_bind_in_range(bind_ip_addr, port_range, 32).expect("tpu multi_bind");
+
+        let (_, tpu_quic) = Self::bind(bind_ip_addr, (tpu_port + 1, tpu_port + 2));
 
         let (tpu_forwards_port, tpu_forwards_sockets) =
             multi_bind_in_range(bind_ip_addr, port_range, 8).expect("tpu_forwards multi_bind");
@@ -2955,6 +2963,7 @@ impl Node {
                 serve_repair,
                 ip_echo: Some(ip_echo),
                 ancestor_hashes_requests,
+                tpu_quic,
             },
         }
     }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -79,6 +79,7 @@ solana-sdk-macro = { path = "macro", version = "=1.10.0" }
 thiserror = "1.0"
 uriparse = "0.6.3"
 wasm-bindgen = "0.2"
+quinn = "0.8.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.55"

--- a/sdk/src/transport.rs
+++ b/sdk/src/transport.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "full")]
 
 use {crate::transaction::TransactionError, std::io, thiserror::Error};
+use quinn::{ConnectionError, SendDatagramError, ConnectError};
 
 #[derive(Debug, Error)]
 pub enum TransportError {
@@ -10,6 +11,15 @@ pub enum TransportError {
     TransactionError(#[from] TransactionError),
     #[error("transport custom error: {0}")]
     Custom(String),
+
+    #[error("transport send error: {0}")]
+    SendDatagramError(#[from] SendDatagramError),
+
+    #[error("transport connect error: {0}")]
+    ConnectionError(#[from] ConnectionError),
+
+    #[error("transport connect error: {0}")]
+    ConnectError(#[from] ConnectError),
 }
 
 impl TransportError {

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -27,6 +27,9 @@ quinn = "0.8.0"
 rcgen = "0.8.14"
 tokio = { version = "1", features = ["full"] }
 rustls = "0.20.2"
+ring = "0.16.20"
+pkcs8 = { version = "0.8.0", features = ["alloc"] }
+pem = "1.0.2"
 
 [dev-dependencies]
 solana-logger = { path = "../logger", version = "=1.10.0" }

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -21,6 +21,13 @@ libc = "0.2.112"
 nix = "0.23.1"
 solana-perf = { path = "../perf", version = "=1.10.0" }
 
+#quiche = "0.10.0"
+futures-util = "0.3.19"
+quinn = "0.8.0"
+rcgen = "0.8.14"
+tokio = { version = "1", features = ["full"] }
+rustls = "0.20.2"
+
 [dev-dependencies]
 solana-logger = { path = "../logger", version = "=1.10.0" }
 

--- a/streamer/src/lib.rs
+++ b/streamer/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::integer_arithmetic)]
 pub mod packet;
+pub mod quic;
 pub mod recvmmsg;
 pub mod sendmmsg;
 pub mod socket;

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -1,0 +1,100 @@
+use crossbeam_channel::Sender;
+use futures_util::stream::StreamExt;
+use quinn::{Endpoint, Incoming, ServerConfig};
+use solana_perf::packet::PacketBatch;
+use solana_sdk::packet::Packet;
+use std::{
+    error::Error,
+    net::{SocketAddr, UdpSocket},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    thread,
+    time::Duration,
+};
+use tokio::runtime::{Builder, Runtime};
+
+/// Returns default server configuration along with its certificate.
+#[allow(clippy::field_reassign_with_default)] // https://github.com/rust-lang/rust-clippy/issues/6527
+fn configure_server() -> Result<(ServerConfig, Vec<u8>), Box<dyn Error>> {
+    let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
+    let cert_der = cert.serialize_der().unwrap();
+    let priv_key = cert.serialize_private_key_der();
+    let priv_key = rustls::PrivateKey(priv_key);
+    let cert_chain = vec![rustls::Certificate(cert_der.clone())];
+
+    let mut server_config = ServerConfig::with_single_cert(cert_chain, priv_key)?;
+    Arc::get_mut(&mut server_config.transport)
+        .unwrap()
+        .max_concurrent_uni_streams(0_u8.into());
+
+    Ok((server_config, cert_der))
+}
+
+/// Constructs a QUIC endpoint configured to listen for incoming connections on a certain address
+/// and port.
+///
+/// ## Returns
+///
+/// - a stream of incoming QUIC connections
+/// - server certificate serialized into DER format
+#[allow(unused)]
+pub fn make_server_endpoint(bind_addr: SocketAddr) -> Result<(Incoming, Vec<u8>), Box<dyn Error>> {
+    let (server_config, server_cert) = configure_server()?;
+    let (_endpoint, incoming) = Endpoint::server(server_config, bind_addr)?;
+    Ok((incoming, server_cert))
+}
+
+fn rt() -> Runtime {
+    Builder::new_current_thread().enable_all().build().unwrap()
+}
+
+pub fn spawn_server(
+    sock: UdpSocket,
+    packet_sender: Sender<PacketBatch>,
+    exit: Arc<AtomicBool>,
+) -> Result<thread::JoinHandle<()>, Box<dyn Error>> {
+    let (config, _cert) = configure_server()?;
+    let handle = thread::spawn(move || {
+        let runtime = rt();
+        let (_, mut incoming) = {
+            let _guard = runtime.enter();
+            Endpoint::new(Default::default(), Some(config), sock).unwrap()
+        };
+        let handle = runtime.spawn(
+            async move {
+                let quinn::NewConnection {
+                    mut uni_streams, ..
+                } = incoming
+                    .next()
+                    .await
+                    .expect("accept")
+                    .await
+                    .expect("connect");
+
+                while let Some(Ok(mut stream)) = uni_streams.next().await {
+                    let packet_sender = packet_sender.clone();
+                    tokio::spawn(async move {
+                        while let Some(chunk) = stream.read_chunk(usize::MAX, false).await.unwrap()
+                        {
+                            let mut batch = PacketBatch::with_capacity(1);
+                            let mut packet = Packet::default();
+                            packet.data.copy_from_slice(&chunk.bytes);
+                            batch.packets.push(packet);
+                            if let Err(e) = packet_sender.send(batch) {
+                                info!("error: {}", e);
+                            }
+                        }
+                    });
+                }
+            }, //.instrument(info!("server")),
+        );
+        //runtime.block_on(handle).unwrap();
+        while !exit.load(Ordering::Relaxed) {
+            thread::sleep(Duration::from_millis(500));
+        }
+        handle.abort();
+    });
+    Ok(handle)
+}

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -1,11 +1,24 @@
 use crossbeam_channel::Sender;
 use futures_util::stream::StreamExt;
 use quinn::{Endpoint, Incoming, ServerConfig};
+use pkcs8::{
+    der::Document,
+    AlgorithmIdentifier,
+    ObjectIdentifier
+};
+use rcgen::{
+    CertificateParams,
+    DistinguishedName,
+    DnType,
+    SanType,
+};
+use pem::Pem;
 use solana_perf::packet::PacketBatch;
 use solana_sdk::packet::Packet;
+use solana_sdk::signature::Keypair;
 use std::{
     error::Error,
-    net::{SocketAddr, UdpSocket},
+    net::{IpAddr, SocketAddr, UdpSocket},
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -15,21 +28,72 @@ use std::{
 };
 use tokio::runtime::{Builder, Runtime};
 
-/// Returns default server configuration along with its certificate.
+/// Returns default server configuration along with its PEM certificate chain.
 #[allow(clippy::field_reassign_with_default)] // https://github.com/rust-lang/rust-clippy/issues/6527
-fn configure_server() -> Result<(ServerConfig, Vec<u8>), Box<dyn Error>> {
-    let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
-    let cert_der = cert.serialize_der().unwrap();
-    let priv_key = cert.serialize_private_key_der();
-    let priv_key = rustls::PrivateKey(priv_key);
-    let cert_chain = vec![rustls::Certificate(cert_der.clone())];
+fn configure_server(identity_keypair: &Keypair, gossip_host: IpAddr) -> Result<(ServerConfig, String), Box<dyn Error>> {
+    let (cert_chain, priv_key) = new_cert(identity_keypair, gossip_host)?;
+    let cert_chain_pem_parts: Vec<Pem> = cert_chain.clone()
+        .into_iter()
+        .map(|cert| Pem {
+            tag: "CERTIFICATE".to_string(),
+            contents: cert.0
+        })
+        .collect();
+    let cert_chain_pem = pem::encode_many(&cert_chain_pem_parts);
 
     let mut server_config = ServerConfig::with_single_cert(cert_chain, priv_key)?;
     Arc::get_mut(&mut server_config.transport)
         .unwrap()
         .max_concurrent_uni_streams(0_u8.into());
 
-    Ok((server_config, cert_der))
+    Ok((server_config, cert_chain_pem))
+}
+
+fn new_cert(identity_keypair: &Keypair, san: IpAddr) -> Result<(Vec<rustls::Certificate>, rustls::PrivateKey), Box<dyn Error>> {
+    let cert_params = new_cert_params(identity_keypair, san);
+    let cert = rcgen::Certificate::from_params(cert_params)?;
+    let cert_der = cert.serialize_der().unwrap();
+    let priv_key = cert.serialize_private_key_der();
+    let priv_key = rustls::PrivateKey(priv_key);
+    let cert_chain = vec![rustls::Certificate(cert_der)];
+    Ok((cert_chain, priv_key))
+}
+
+fn new_cert_params(identity_keypair: &Keypair, san: IpAddr) -> CertificateParams {
+    // TODO(terorie): Is it safe to sign the TLS cert with the identity private key?
+
+    // Unfortunately, rcgen does not accept a "raw" Ed25519 key.
+    // We have to convert it to DER and pass it to the library.
+
+    // Convert private key into PKCS#8 v1 object.
+    // RFC 8410, Section 7: Private Key Format
+    // https://datatracker.ietf.org/doc/html/rfc8410#section-7
+    let mut private_key = Vec::<u8>::with_capacity(34);
+    private_key.extend_from_slice(&[0x04, 0x20]); // ASN.1 OCTET STRING
+    private_key.extend_from_slice(identity_keypair.secret().as_bytes());
+    let key_pkcs8 = pkcs8::PrivateKeyInfo {
+        algorithm: AlgorithmIdentifier {
+            oid: ObjectIdentifier::from_arcs(&[1, 3, 101, 112]).unwrap(),
+            parameters: None,
+        },
+        private_key: &private_key,
+        public_key: None,
+    };
+    let key_pkcs8_der = key_pkcs8.to_der()
+        .expect("Failed to convert keypair to DER")
+        .to_der();
+
+    // Parse private key into rcgen::KeyPair struct.
+    let keypair = rcgen::KeyPair::from_der(&key_pkcs8_der)
+        .expect("Failed to parse keypair from DER");
+
+    let mut cert_params: CertificateParams = Default::default();
+    cert_params.subject_alt_names = vec![SanType::IpAddress(san)];
+    cert_params.alg = &rcgen::PKCS_ED25519;
+    cert_params.key_pair = Some(keypair);
+    cert_params.distinguished_name = DistinguishedName::new();
+    cert_params.distinguished_name.push(DnType::CommonName, "Solana node");
+    cert_params
 }
 
 /// Constructs a QUIC endpoint configured to listen for incoming connections on a certain address
@@ -40,8 +104,9 @@ fn configure_server() -> Result<(ServerConfig, Vec<u8>), Box<dyn Error>> {
 /// - a stream of incoming QUIC connections
 /// - server certificate serialized into DER format
 #[allow(unused)]
-pub fn make_server_endpoint(bind_addr: SocketAddr) -> Result<(Incoming, Vec<u8>), Box<dyn Error>> {
-    let (server_config, server_cert) = configure_server()?;
+pub fn make_server_endpoint(bind_addr: SocketAddr, keypair: &Keypair) -> Result<(Incoming, String), Box<dyn Error>> {
+    // TODO(terorie) Bind address is not appropriate for SAN (could be 0.0.0.0)
+    let (server_config, server_cert) = configure_server(keypair, bind_addr.ip())?;
     let (_endpoint, incoming) = Endpoint::server(server_config, bind_addr)?;
     Ok((incoming, server_cert))
 }
@@ -52,10 +117,12 @@ fn rt() -> Runtime {
 
 pub fn spawn_server(
     sock: UdpSocket,
+    keypair: &Keypair,
+    gossip_host: IpAddr,
     packet_sender: Sender<PacketBatch>,
     exit: Arc<AtomicBool>,
 ) -> Result<thread::JoinHandle<()>, Box<dyn Error>> {
-    let (config, _cert) = configure_server()?;
+    let (config, _cert) = configure_server(keypair, gossip_host)?;
     let handle = thread::spawn(move || {
         let runtime = rt();
         let (_, mut incoming) = {
@@ -97,4 +164,18 @@ pub fn spawn_server(
         handle.abort();
     });
     Ok(handle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn test_configure_server() {
+        let keypair = Keypair::new();
+        let san = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        let (_server_config, cert) = configure_server(&keypair, san).unwrap();
+        println!("{}", cert);
+    }
 }


### PR DESCRIPTION
This allows the validator to reuse it's identity key to self-sign the TPU server certificate.

- streamer: Adds gossip IP address as X.509 subject alternative name
- streamer: Signs cert using validator identity key

There's a security concern with signing certs directly with the validator key.
We have to make sure that this signing process can never be used to forge consensus message or transaction signatures.

--------

In the future, TPU clients could serve a client cert using the same mechanism too.
This would hopefully allow the validator to apply basic QoS based on node identity, e.g. giving identity keys that have been observed in gossip longer more TPU bandwidth.